### PR TITLE
Include custom riemann rules.

### DIFF
--- a/jobs/riemann/spec
+++ b/jobs/riemann/spec
@@ -32,6 +32,9 @@ properties:
     description: "Password to authenticate with."
     default: ""
 
+  riemann.custom_rules:
+    description: "Custom alert rules"
+
   consul.agent.services.riemann:
     description: "this property auto-registers TSA as a service"
     default: {}

--- a/jobs/riemann/templates/config/riemann.config.erb
+++ b/jobs/riemann/templates/config/riemann.config.erb
@@ -50,6 +50,8 @@
           (influx-with-tags event)))
 <% end %>
 
+<% p("riemann.custom_rules", []).each |rule| %><%= rule %><% end %>
+
       ; Log expired events.
       (expired
         (fn [event] (info "expired" event))))))


### PR DESCRIPTION
Based on the `custom_rules` property from
https://github.com/hybris/riemann-boshrelease, using an array instead of
a string to allow configuration like this:

```yml
properties:
  riemann:
    custom_rules:
    - (( file "rules/rds.clj" ))
    - (( file "rules/elastic.clj" ))
```